### PR TITLE
removendo a duplicação

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -5,17 +5,14 @@ provider "aws" {
 
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
-  version = "3.0"
-
-  name = "eks-vpc"
-  cidr = "10.0.0.0/16"
-  azs  = ["us-east-1a", "us-east-1b"]
-
-  private_subnets = ["10.0.1.0/24", "10.0.2.0/24"]
-  public_subnets  = ["10.0.3.0/24", "10.0.4.0/24"]
-
-  enable_nat_gateway = true
-  single_nat_gateway = true
+  # Remova a versão ou defina a versão mais recente.
+  name                 = "eks-vpc"
+  cidr                 = "10.0.0.0/16"
+  azs                  = ["us-east-1a", "us-east-1b"]
+  private_subnets      = ["10.0.1.0/24", "10.0.2.0/24"]
+  public_subnets       = ["10.0.3.0/24", "10.0.4.0/24"]
+  enable_nat_gateway   = true
+  single_nat_gateway   = true
 }
 
 

--- a/terraform/security_groups.tf
+++ b/terraform/security_groups.tf
@@ -7,7 +7,7 @@ resource "aws_security_group" "eks_security_group" {
     from_port        = 443
     to_port          = 443
     protocol         = "tcp"
-    cidr_blocks      = ["<your-office-ip>/32"]
+    cidr_blocks      = ["0.0.0.0/32"]
   }
 
   egress {


### PR DESCRIPTION
## Summary by Sourcery

Remove the version specification for the VPC module and update the security group ingress rule to allow traffic from any IP address.

Enhancements:
- Remove the version specification for the VPC module to allow using the latest version.

Deployment:
- Update the security group ingress rule to allow traffic from any IP address.